### PR TITLE
checking if initial token during first load is undefined

### DIFF
--- a/client/src/utils/auth.ts
+++ b/client/src/utils/auth.ts
@@ -11,7 +11,9 @@ class AuthService {
   loggedIn() {
     // TODO: return a value that indicates if the user is logged in
     const token = this.getToken();
-    if(token) {
+    if (token === 'undefined'){
+      localStorage.removeItem('token');
+    }else if(token) {
       const isExpired = this.isTokenExpired(token);
       return token && !isExpired;
     } else {


### PR DESCRIPTION
checking if initial token during first load is undefined. This is because when first loading the site on render, the token is set to undefined and leads to a 404 error. If the token is undefined now, it will remove it from local storage.